### PR TITLE
Add river configuration property headers_to_fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Prerequisites:
 * ``with_flag_sync`` - IMAP only: if ``true`` then message flag changes will be detected and indexed. Maybe slow for very huge mailboxes. (default: ``true``)
 * ``index_settings`` - optional settings for the Elasticsearch index
 * ``type_mapping`` - optional mapping for the Elasticsearch index type
+* ``headers_to_fields`` - array with e-mail header names to include as proper fields. To create a legal field name, the header name is prefixed with ``header_``, lowercased and has all non-alphanumeric characters replaced with ``_``. For example, an input of ``["Message-ID"]`` will copy that header into a field with name ``header_message_id``.
 
 Note: For POP3 only the "INBOX" folder is supported. This is a limitation of the POP3 protocol.
 

--- a/src/main/java/de/saly/elasticsearch/maildestination/ElasticsearchBulkMailDestination.java
+++ b/src/main/java/de/saly/elasticsearch/maildestination/ElasticsearchBulkMailDestination.java
@@ -153,7 +153,7 @@ public class ElasticsearchBulkMailDestination extends ElasticsearchMailDestinati
         }
 
         final IndexableMailMessage imsg = IndexableMailMessage.fromJavaMailMessage(msg, isWithTextContent(), isWithAttachments(),
-                isStripTagsFromTextContent());
+                isStripTagsFromTextContent(), getHeadersToFields());
 
         if (logger.isTraceEnabled()) {
             logger.trace("Bulk process mail " + imsg.getUid() + "/" + imsg.getPopId() + " :: " + imsg.getSubject() + "/"

--- a/src/main/java/de/saly/elasticsearch/maildestination/ElasticsearchMailDestination.java
+++ b/src/main/java/de/saly/elasticsearch/maildestination/ElasticsearchMailDestination.java
@@ -29,6 +29,7 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -84,6 +85,8 @@ public class ElasticsearchMailDestination implements MailDestination {
     private boolean withAttachments = false;
 
     private boolean withTextContent = true;
+
+    private List<String> headersToFields;
 
     protected final ESLogger logger = ESLoggerFactory.getLogger(this.getClass().getName());
 
@@ -210,6 +213,10 @@ public class ElasticsearchMailDestination implements MailDestination {
 
     }
 
+    public List<String> getHeadersToFields() {
+        return headersToFields;
+    }
+
     public boolean isStripTagsFromTextContent() {
         return stripTagsFromTextContent;
     }
@@ -239,7 +246,7 @@ public class ElasticsearchMailDestination implements MailDestination {
         }
 
         final IndexableMailMessage imsg = IndexableMailMessage.fromJavaMailMessage(msg, withTextContent, withAttachments,
-                stripTagsFromTextContent);
+                stripTagsFromTextContent, headersToFields);
 
         if (logger.isTraceEnabled()) {
             logger.trace("Process mail " + imsg.getUid() + "/" + imsg.getPopId() + " :: " + imsg.getSubject() + "/" + imsg.getSentDate());
@@ -307,6 +314,11 @@ public class ElasticsearchMailDestination implements MailDestination {
 
     public ElasticsearchMailDestination setWithTextContent(final boolean withTextContent) {
         this.withTextContent = withTextContent;
+        return this;
+    }
+
+    public MailDestination setHeadersToFields(List<String> headersToFields) {
+        this.headersToFields = headersToFields;
         return this;
     }
 


### PR DESCRIPTION
I ran into a small problem when indexing mailing list archives. Since the e-mail headers are stored in an array of an inner object, the names and values get flattened when indexing. This means that while it's possible to filter on a header like "Message-ID" by using field name "header.value", it's not possible to know if it's that header or another, like "References" or "In-Reply-To" that's actually matching.

Since one probably doesn't want to create fields for all headers, I've added a new river configuration property (headers_to_fields) where one can list headers that should be copied to fields.

A header name like "Message-ID" creates a field with name "header_message_id".
